### PR TITLE
Add CodeQuest desktop scaffold

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,0 +1,10 @@
+# CodeQuest Desktop
+
+This folder contains a minimal scaffold for the **CodeQuest** desktop application. The app aims to provide an offline environment for solving programming challenges in Go and Python.
+
+## Goals
+- Run fully offline on Windows, macOS and Linux using Tauri.
+- Ship language runtimes and judge logic so that users can solve problems without installing any additional tools.
+- Provide a VS Code–like editor experience via Monaco Editor.
+
+This folder only includes a placeholder structure. The actual implementation of the features described in the project specification is left for future work.

--- a/desktop/apps/desktop/frontend/index.html
+++ b/desktop/apps/desktop/frontend/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>CodeQuest</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./src/App.tsx"></script>
+  </body>
+</html>

--- a/desktop/apps/desktop/frontend/src/App.tsx
+++ b/desktop/apps/desktop/frontend/src/App.tsx
@@ -1,0 +1,5 @@
+export function App() {
+  return <h1>CodeQuest Desktop</h1>;
+}
+
+export default App;

--- a/desktop/apps/desktop/src-tauri/Cargo.toml
+++ b/desktop/apps/desktop/src-tauri/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "codequest"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+tauri = { version = "1", features = ["api-all"] }

--- a/desktop/apps/desktop/src-tauri/judge/mod.rs
+++ b/desktop/apps/desktop/src-tauri/judge/mod.rs
@@ -1,0 +1,3 @@
+pub fn judge(_code: &str) {
+    // Placeholder for offline judge logic
+}

--- a/desktop/apps/desktop/src-tauri/runtimes/go/README.md
+++ b/desktop/apps/desktop/src-tauri/runtimes/go/README.md
@@ -1,0 +1,1 @@
+Placeholder for Go WASM runtime

--- a/desktop/apps/desktop/src-tauri/runtimes/python/README.md
+++ b/desktop/apps/desktop/src-tauri/runtimes/python/README.md
@@ -1,0 +1,1 @@
+Placeholder for Python WASM runtime

--- a/desktop/apps/desktop/src-tauri/src/main.rs
+++ b/desktop/apps/desktop/src-tauri/src/main.rs
@@ -1,0 +1,8 @@
+mod judge;
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+fn main() {
+    tauri::Builder::default()
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}

--- a/desktop/apps/desktop/tauri.conf.json
+++ b/desktop/apps/desktop/tauri.conf.json
@@ -1,0 +1,11 @@
+{
+  "tauri": {
+    "bundle": {
+      "identifier": "com.example.codequest",
+      "icon": ["icons/icon.png"]
+    },
+    "updater": {
+      "active": true
+    }
+  }
+}

--- a/desktop/problems/problem_list.json
+++ b/desktop/problems/problem_list.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "sample-problem",
+    "title": "Sample Problem",
+    "difficulty": "easy"
+  }
+]

--- a/desktop/problems/sample-problem/description.md
+++ b/desktop/problems/sample-problem/description.md
@@ -1,0 +1,3 @@
+# Sample Problem
+
+Implement a program that reads a line from stdin and echoes it back.

--- a/desktop/problems/sample-problem/tests.json
+++ b/desktop/problems/sample-problem/tests.json
@@ -1,0 +1,6 @@
+[
+  {
+    "input": "hello\n",
+    "output": "hello\n"
+  }
+]


### PR DESCRIPTION
## Summary
- introduce placeholder desktop app scaffold under `desktop`
- add Tauri config and minimal Rust entry point
- stub front-end with an index page
- include sample problem data

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68615118e9e0832c8d934189ed6e22c2