### PR TITLE
feat: add authentication Redux slice

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -6,7 +6,6 @@ import * as usePyodideModule from '@/features/editor';
 import * as useResizableLayoutModule from '@/shared';
 import * as useAppContextModule from '@/contexts';
 import * as useCodeExecutionModule from '@/features/editor';
-import * as useAuthModule from '@/features/auth';
 import { User } from 'firebase/auth';
 
 // Mock all the hooks and components
@@ -98,8 +97,9 @@ jest.mock('@/features/question', () => ({
   ),
 }));
 
-jest.mock('@/features/auth', () => ({
-  useAuth: jest.fn(),
+jest.mock('@/contexts', () => ({
+  useAppContext: jest.fn(),
+  useAuthContext: jest.fn(),
 }));
 
 // Get mocked functions
@@ -111,7 +111,7 @@ const mockUseAppContext = jest.mocked(useAppContextModule.useAppContext);
 const mockUseCodeExecution = jest.mocked(
   useCodeExecutionModule.useCodeExecution
 );
-const mockUseAuth = jest.mocked(useAuthModule.useAuth);
+const mockUseAuthContext = jest.mocked(useAppContextModule.useAuthContext);
 
 describe('App', () => {
   const mockExecuteCode = jest.fn();
@@ -201,8 +201,9 @@ describe('App', () => {
       requiresAuth: jest.fn(() => false),
     });
 
-    mockUseAuth.mockReturnValue({
+    mockUseAuthContext.mockReturnValue({
       isAuthorizedForGo: true,
+      isAuthenticated: true,
       user: {
         email: 'test@example.com',
         emailVerified: true,
@@ -225,6 +226,8 @@ describe('App', () => {
       login: jest.fn(),
       logout: jest.fn(),
       loading: false,
+      error: null,
+      clearError: jest.fn(),
     });
   });
 
@@ -343,12 +346,15 @@ describe('App', () => {
   });
 
   it('should show error when user is not authorized for Go', async () => {
-    mockUseAuth.mockReturnValue({
+    mockUseAuthContext.mockReturnValue({
       isAuthorizedForGo: false,
+      isAuthenticated: false,
       user: null,
       login: jest.fn(),
       logout: jest.fn(),
       loading: false,
+      error: null,
+      clearError: jest.fn(),
     });
 
     // Update state to use Go

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { usePyodide, useCodeExecution } from '@/features/editor';
 import { useResizableLayout } from '@/shared';
 import { useAppContext } from '@/contexts';
-import { useAuth } from '@/features/auth';
+import { useAuthContext } from '@/contexts';
 import { Header, MainLayout, RightPane, MobileUsageTip } from '@/shared';
 import { ProblemDescription } from '@/features/question';
 import { ExecutionMode, SubmissionResult } from '@/shared/types';
@@ -32,7 +32,7 @@ const App: React.FC = () => {
     setIsRunning,
   } = useAppContext();
   const { executeCode, executeAndSubmit } = useCodeExecution(pyodideManager);
-  const { isAuthorizedForGo, user } = useAuth();
+  const { isAuthorizedForGo, user } = useAuthContext();
 
   // Force editor to update when language changes
   const [editorKey, setEditorKey] = React.useState(0);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 import ThemeProvider from '@/shared/components/ThemeProvider';
 import ReduxProvider from '@/shared/components/ReduxProvider';
-import { AppProvider } from '@/contexts/AppContext';
+import { AppProvider, AuthProvider } from '@/contexts';
 import { Suspense } from 'react';
 
 const geistSans = Geist({
@@ -52,9 +52,11 @@ export default function RootLayout({
       >
         <ThemeProvider>
           <ReduxProvider>
-            <Suspense fallback={<div>Loading...</div>}>
-              <AppProvider>{children}</AppProvider>
-            </Suspense>
+            <AuthProvider>
+              <Suspense fallback={<div>Loading...</div>}>
+                <AppProvider>{children}</AppProvider>
+              </Suspense>
+            </AuthProvider>
           </ReduxProvider>
         </ThemeProvider>
       </body>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,110 @@
+'use client';
+import React, {
+  createContext,
+  useContext,
+  useCallback,
+  useEffect,
+} from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { AppDispatch } from '@/store';
+import {
+  selectUser,
+  selectIsAuthenticated,
+  selectIsAuthorizedForGo,
+  selectAuthLoading,
+  selectAuthError,
+  loginWithGoogle,
+  logoutUser,
+  setUser,
+  clearError,
+} from '@/store/slices/authSlice';
+import { onAuthStateChange } from '@/shared/lib';
+
+interface AuthContextType {
+  // State
+  user: ReturnType<typeof selectUser>;
+  isAuthenticated: ReturnType<typeof selectIsAuthenticated>;
+  isAuthorizedForGo: ReturnType<typeof selectIsAuthorizedForGo>;
+  loading: ReturnType<typeof selectAuthLoading>;
+  error: ReturnType<typeof selectAuthError>;
+
+  // Actions
+  login: () => Promise<void>;
+  logout: () => Promise<void>;
+  clearError: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const useAuthContext = () => {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error('useAuthContext must be used within an AuthProvider');
+  }
+  return context;
+};
+
+interface AuthProviderProps {
+  children: React.ReactNode;
+}
+
+export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
+  const dispatch = useDispatch<AppDispatch>();
+
+  // Selectors
+  const user = useSelector(selectUser);
+  const isAuthenticated = useSelector(selectIsAuthenticated);
+  const isAuthorizedForGo = useSelector(selectIsAuthorizedForGo);
+  const loading = useSelector(selectAuthLoading);
+  const error = useSelector(selectAuthError);
+
+  // Actions
+  const login = useCallback(async () => {
+    try {
+      await dispatch(loginWithGoogle()).unwrap();
+    } catch (error) {
+      console.error('Login failed:', error);
+      throw error;
+    }
+  }, [dispatch]);
+
+  const logout = useCallback(async () => {
+    try {
+      await dispatch(logoutUser()).unwrap();
+    } catch (error) {
+      console.error('Logout failed:', error);
+      throw error;
+    }
+  }, [dispatch]);
+
+  const clearErrorAction = useCallback(() => {
+    dispatch(clearError());
+  }, [dispatch]);
+
+  // Sync with Firebase auth state
+  useEffect(() => {
+    const unsubscribe = onAuthStateChange((user) => {
+      dispatch(setUser(user));
+    });
+
+    return () => unsubscribe();
+  }, [dispatch]);
+
+  const contextValue: AuthContextType = {
+    // State
+    user,
+    isAuthenticated,
+    isAuthorizedForGo,
+    loading,
+    error,
+
+    // Actions
+    login,
+    logout,
+    clearError: clearErrorAction,
+  };
+
+  return (
+    <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>
+  );
+};

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,1 +1,2 @@
 export { AppProvider, useAppContext } from './AppContext';
+export { AuthProvider, useAuthContext } from './AuthContext';

--- a/src/features/auth/components/AuthButton.tsx
+++ b/src/features/auth/components/AuthButton.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { useAuth } from '@/features/auth';
+import { useAuthContext } from '@/contexts';
 
 const AuthButton: React.FC = () => {
-  const { user, loading, login, logout } = useAuth();
+  const { user, loading, login, logout } = useAuthContext();
 
   if (loading) {
     return (

--- a/src/features/auth/components/LanguageSelector.tsx
+++ b/src/features/auth/components/LanguageSelector.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { SUPPORTED_LANGUAGES } from '@/shared/constants';
-import { useAuth } from '@/features/auth';
+import { useAuthContext } from '@/contexts';
 
 interface LanguageSelectorProps {
   selectedLanguage: string;
@@ -11,7 +11,7 @@ const LanguageSelector: React.FC<LanguageSelectorProps> = ({
   selectedLanguage,
   onLanguageChange,
 }) => {
-  const { isAuthorizedForGo } = useAuth();
+  const { isAuthorizedForGo } = useAuthContext();
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 

--- a/src/features/editor/__tests__/SubmissionFlow.integration.test.tsx
+++ b/src/features/editor/__tests__/SubmissionFlow.integration.test.tsx
@@ -9,8 +9,17 @@ import { PyodideManager, TestCase, CodeExecutionResult } from '@/shared/types';
 // Mock the services
 jest.mock('../services/CodeExecutionService');
 jest.mock('../services/SubmissionService');
-jest.mock('@/features/auth', () => ({
-  useAuth: () => ({ user: { email: 'test@example.com' } }),
+jest.mock('@/contexts', () => ({
+  useAuthContext: () => ({
+    user: { email: 'test@example.com' },
+    isAuthenticated: true,
+    isAuthorizedForGo: true,
+    loading: false,
+    error: null,
+    login: jest.fn(),
+    logout: jest.fn(),
+    clearError: jest.fn(),
+  }),
 }));
 
 const MockedCodeExecutionService = CodeExecutionService as jest.MockedClass<

--- a/src/features/editor/hooks/__tests__/useCodeExecution.test.ts
+++ b/src/features/editor/hooks/__tests__/useCodeExecution.test.ts
@@ -2,11 +2,20 @@ import { renderHook, act } from '@testing-library/react';
 import { useCodeExecution } from '../useCodeExecution';
 import { CodeExecutionService } from '../../services';
 import { TestCase, CodeExecutionResult, PyodideManager } from '@/shared/types';
-import * as useAuthModule from '@/features/auth';
-
 // Mock the service
 jest.mock('../../services');
-jest.mock('@/features/auth');
+jest.mock('@/contexts', () => ({
+  useAuthContext: () => ({
+    user: null,
+    isAuthenticated: false,
+    isAuthorizedForGo: false,
+    loading: false,
+    error: null,
+    login: jest.fn(),
+    logout: jest.fn(),
+    clearError: jest.fn(),
+  }),
+}));
 
 const mockExecuteCode = jest.fn();
 const mockIsLanguageAvailable = jest.fn();
@@ -15,9 +24,6 @@ const mockRequiresAuth = jest.fn();
 const MockCodeExecutionService = CodeExecutionService as jest.MockedClass<
   typeof CodeExecutionService
 >;
-
-// Mock useAuth hook
-const mockUseAuth = jest.mocked(useAuthModule.useAuth);
 
 describe('useCodeExecution', () => {
   const mockPyodideManager = {
@@ -37,15 +43,6 @@ describe('useCodeExecution', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-
-    // Mock useAuth to return expected structure
-    mockUseAuth.mockReturnValue({
-      user: null,
-      login: jest.fn(),
-      logout: jest.fn(),
-      loading: false,
-      isAuthorizedForGo: false,
-    });
 
     MockCodeExecutionService.mockImplementation(
       () =>

--- a/src/features/editor/hooks/useCodeExecution.ts
+++ b/src/features/editor/hooks/useCodeExecution.ts
@@ -1,16 +1,16 @@
 import { useCallback, useMemo } from 'react';
-import { 
-  TestCase, 
-  CodeExecutionResult, 
-  PyodideManager, 
-  ExecutionMode, 
-  SubmissionResult 
+import {
+  TestCase,
+  CodeExecutionResult,
+  PyodideManager,
+  ExecutionMode,
+  SubmissionResult,
 } from '@/shared/types';
 import { CodeExecutionService } from '../services';
-import { useAuth } from '@/features/auth';
+import { useAuthContext } from '@/contexts';
 
 export const useCodeExecution = (pyodideManager: PyodideManager) => {
-  const { user } = useAuth();
+  const { user } = useAuthContext();
 
   const executionService = useMemo(
     () => new CodeExecutionService(pyodideManager, user),
@@ -22,14 +22,23 @@ export const useCodeExecution = (pyodideManager: PyodideManager) => {
       code: string,
       testCases: TestCase[],
       language: string,
-      mode: ExecutionMode = { type: 'RUN', testCaseLimit: 2, createSnapshot: false }
+      mode: ExecutionMode = {
+        type: 'RUN',
+        testCaseLimit: 2,
+        createSnapshot: false,
+      }
     ): Promise<CodeExecutionResult> => {
       console.log(
         `Executing ${language} code in ${mode.type} mode:`,
         code.substring(0, 100) + '...'
       );
 
-      return await executionService.executeCode(code, testCases, language, mode);
+      return await executionService.executeCode(
+        code,
+        testCases,
+        language,
+        mode
+      );
     },
     [executionService]
   );
@@ -40,13 +49,21 @@ export const useCodeExecution = (pyodideManager: PyodideManager) => {
       testCases: TestCase[],
       language: string,
       questionId: string
-    ): Promise<{ result: CodeExecutionResult; submission: SubmissionResult }> => {
+    ): Promise<{
+      result: CodeExecutionResult;
+      submission: SubmissionResult;
+    }> => {
       console.log(
         `Submitting ${language} code for question ${questionId}:`,
         code.substring(0, 100) + '...'
       );
 
-      return await executionService.executeAndSubmit(code, testCases, language, questionId);
+      return await executionService.executeAndSubmit(
+        code,
+        testCases,
+        language,
+        questionId
+      );
     },
     [executionService]
   );

--- a/src/shared/components/DebugPanel.tsx
+++ b/src/shared/components/DebugPanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useAuth } from '@/features/auth';
+import { useAuthContext } from '@/contexts';
 import { Question, TestResult } from '@/shared/types';
 
 interface DebugPanelProps {
@@ -22,7 +22,7 @@ const DebugPanel: React.FC<DebugPanelProps> = ({
   testResults,
   pyodideManager,
 }) => {
-  const { user, isAuthorizedForGo } = useAuth();
+  const { user, isAuthorizedForGo } = useAuthContext();
 
   return (
     <div className="bg-yellow-50 border border-yellow-200 p-4 rounded mb-4">

--- a/src/store/__tests__/authSlice.test.ts
+++ b/src/store/__tests__/authSlice.test.ts
@@ -1,0 +1,214 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { User } from 'firebase/auth';
+import authReducer, {
+  setUser,
+  setLoading,
+  setError,
+  clearError,
+  loginWithGoogle,
+  logoutUser,
+  selectUser,
+  selectIsAuthenticated,
+  selectIsAuthorizedForGo,
+  selectAuthLoading,
+  selectAuthError,
+} from '../slices/authSlice';
+
+// Mock Firebase auth functions
+jest.mock('@/shared/lib', () => ({
+  signInWithGoogle: jest.fn(),
+  signOutUser: jest.fn(),
+  onAuthStateChange: jest.fn(),
+}));
+
+const createTestStore = () =>
+  configureStore({
+    reducer: {
+      auth: authReducer,
+    },
+  });
+
+describe('Auth Slice', () => {
+  describe('initial state', () => {
+    it('should have correct initial state', () => {
+      const store = createTestStore();
+      const state = store.getState();
+
+      expect(state.auth).toEqual({
+        user: null,
+        loading: true,
+        isAuthorizedForGo: false,
+        error: null,
+      });
+    });
+  });
+
+  describe('reducers', () => {
+    it('should handle setUser', () => {
+      const store = createTestStore();
+      const mockUser = { uid: '123', email: 'test@example.com' } as User;
+
+      store.dispatch(setUser(mockUser));
+
+      const state = store.getState();
+      expect(state.auth.user).toEqual(mockUser);
+      expect(state.auth.isAuthorizedForGo).toBe(true);
+      expect(state.auth.loading).toBe(false);
+      expect(state.auth.error).toBe(null);
+    });
+
+    it('should handle setUser with null', () => {
+      const store = createTestStore();
+
+      store.dispatch(setUser(null));
+
+      const state = store.getState();
+      expect(state.auth.user).toBe(null);
+      expect(state.auth.isAuthorizedForGo).toBe(false);
+      expect(state.auth.loading).toBe(false);
+    });
+
+    it('should handle setLoading', () => {
+      const store = createTestStore();
+
+      store.dispatch(setLoading(false));
+
+      const state = store.getState();
+      expect(state.auth.loading).toBe(false);
+    });
+
+    it('should handle setError', () => {
+      const store = createTestStore();
+
+      store.dispatch(setError('Test error'));
+
+      const state = store.getState();
+      expect(state.auth.error).toBe('Test error');
+    });
+
+    it('should handle clearError', () => {
+      const store = createTestStore();
+
+      // Set an error first
+      store.dispatch(setError('Test error'));
+      expect(store.getState().auth.error).toBe('Test error');
+
+      // Clear the error
+      store.dispatch(clearError());
+      expect(store.getState().auth.error).toBe(null);
+    });
+  });
+
+  describe('selectors', () => {
+    it('should select user correctly', () => {
+      const store = createTestStore();
+      const mockUser = { uid: '123', email: 'test@example.com' } as User;
+
+      store.dispatch(setUser(mockUser));
+
+      const user = selectUser(store.getState());
+      expect(user).toEqual(mockUser);
+    });
+
+    it('should select isAuthenticated correctly', () => {
+      const store = createTestStore();
+
+      // Initially not authenticated
+      expect(selectIsAuthenticated(store.getState())).toBe(false);
+
+      // After setting user
+      const mockUser = { uid: '123', email: 'test@example.com' } as User;
+      store.dispatch(setUser(mockUser));
+      expect(selectIsAuthenticated(store.getState())).toBe(true);
+    });
+
+    it('should select isAuthorizedForGo correctly', () => {
+      const store = createTestStore();
+
+      // Initially not authorized
+      expect(selectIsAuthorizedForGo(store.getState())).toBe(false);
+
+      // After setting user
+      const mockUser = { uid: '123', email: 'test@example.com' } as User;
+      store.dispatch(setUser(mockUser));
+      expect(selectIsAuthorizedForGo(store.getState())).toBe(true);
+    });
+
+    it('should select loading correctly', () => {
+      const store = createTestStore();
+
+      expect(selectAuthLoading(store.getState())).toBe(true);
+
+      store.dispatch(setLoading(false));
+      expect(selectAuthLoading(store.getState())).toBe(false);
+    });
+
+    it('should select error correctly', () => {
+      const store = createTestStore();
+
+      expect(selectAuthError(store.getState())).toBe(null);
+
+      store.dispatch(setError('Test error'));
+      expect(selectAuthError(store.getState())).toBe('Test error');
+    });
+  });
+
+  describe('async thunks', () => {
+    it('should handle loginWithGoogle.pending', () => {
+      const store = createTestStore();
+
+      store.dispatch(loginWithGoogle.pending('', undefined));
+
+      const state = store.getState();
+      expect(state.auth.loading).toBe(true);
+      expect(state.auth.error).toBe(null);
+    });
+
+    it('should handle loginWithGoogle.fulfilled', () => {
+      const store = createTestStore();
+      const mockUser = { uid: '123', email: 'test@example.com' } as User;
+
+      store.dispatch(loginWithGoogle.fulfilled(mockUser, '', undefined));
+
+      const state = store.getState();
+      expect(state.auth.user).toEqual(mockUser);
+      expect(state.auth.isAuthorizedForGo).toBe(true);
+      expect(state.auth.loading).toBe(false);
+      expect(state.auth.error).toBe(null);
+    });
+
+    it('should handle loginWithGoogle.rejected', () => {
+      const store = createTestStore();
+
+      store.dispatch(
+        loginWithGoogle.rejected(
+          new Error('Login failed'),
+          '',
+          undefined,
+          'Login failed'
+        )
+      );
+
+      const state = store.getState();
+      expect(state.auth.loading).toBe(false);
+      expect(state.auth.error).toBe('Login failed');
+    });
+
+    it('should handle logoutUser.fulfilled', () => {
+      const store = createTestStore();
+
+      // Set a user first
+      const mockUser = { uid: '123', email: 'test@example.com' } as User;
+      store.dispatch(setUser(mockUser));
+
+      // Then logout
+      store.dispatch(logoutUser.fulfilled(null, '', undefined));
+
+      const state = store.getState();
+      expect(state.auth.user).toBe(null);
+      expect(state.auth.isAuthorizedForGo).toBe(false);
+      expect(state.auth.loading).toBe(false);
+      expect(state.auth.error).toBe(null);
+    });
+  });
+});

--- a/src/store/__tests__/store.test.ts
+++ b/src/store/__tests__/store.test.ts
@@ -10,9 +10,10 @@ describe('Redux Store', () => {
       expect(typeof store.subscribe).toBe('function');
     });
 
-    it('should have the app reducer', () => {
+    it('should have the app and auth reducers', () => {
       const state = store.getState();
       expect(state).toHaveProperty('app');
+      expect(state).toHaveProperty('auth');
     });
 
     it('should have correct initial state', () => {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import appReducer from './slices/appSlice';
+import authReducer from './slices/authSlice';
 
 export const store = configureStore({
   reducer: {
     app: appReducer,
+    auth: authReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({
@@ -13,7 +15,7 @@ export const store = configureStore({
         // Ignore these field paths in all actions
         ignoredActionPaths: ['payload.timestamp'],
         // Ignore these paths in the state
-        ignoredPaths: ['app.currentQuestion'],
+        ignoredPaths: ['app.currentQuestion', 'auth.user'],
       },
     }),
 });

--- a/src/store/slices/authSlice.ts
+++ b/src/store/slices/authSlice.ts
@@ -1,0 +1,116 @@
+import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
+import { User } from 'firebase/auth';
+import { signInWithGoogle, signOutUser } from '@/shared/lib';
+
+export interface AuthState {
+  user: User | null;
+  loading: boolean;
+  isAuthorizedForGo: boolean;
+  error: string | null;
+}
+
+const initialState: AuthState = {
+  user: null,
+  loading: true,
+  isAuthorizedForGo: false,
+  error: null,
+};
+
+// Async thunks
+export const loginWithGoogle = createAsyncThunk(
+  'auth/loginWithGoogle',
+  async (_, { rejectWithValue }) => {
+    try {
+      const user = await signInWithGoogle();
+      return user;
+    } catch (error) {
+      return rejectWithValue(
+        error instanceof Error ? error.message : 'Login failed'
+      );
+    }
+  }
+);
+
+export const logoutUser = createAsyncThunk(
+  'auth/logoutUser',
+  async (_, { rejectWithValue }) => {
+    try {
+      await signOutUser();
+      return null;
+    } catch (error) {
+      return rejectWithValue(
+        error instanceof Error ? error.message : 'Logout failed'
+      );
+    }
+  }
+);
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    setUser: (state, action: PayloadAction<User | null>) => {
+      state.user = action.payload;
+      state.isAuthorizedForGo = !!action.payload;
+      state.loading = false;
+      state.error = null;
+    },
+    setLoading: (state, action: PayloadAction<boolean>) => {
+      state.loading = action.payload;
+    },
+    setError: (state, action: PayloadAction<string | null>) => {
+      state.error = action.payload;
+    },
+    clearError: (state) => {
+      state.error = null;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      // Login with Google
+      .addCase(loginWithGoogle.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(loginWithGoogle.fulfilled, (state, action) => {
+        state.user = action.payload;
+        state.isAuthorizedForGo = !!action.payload;
+        state.loading = false;
+        state.error = null;
+      })
+      .addCase(loginWithGoogle.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload as string;
+      })
+      // Logout
+      .addCase(logoutUser.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(logoutUser.fulfilled, (state) => {
+        state.user = null;
+        state.isAuthorizedForGo = false;
+        state.loading = false;
+        state.error = null;
+      })
+      .addCase(logoutUser.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload as string;
+      });
+  },
+});
+
+export const { setUser, setLoading, setError, clearError } = authSlice.actions;
+
+// Selectors
+export const selectAuthState = (state: { auth: AuthState }) => state.auth;
+export const selectUser = (state: { auth: AuthState }) => state.auth.user;
+export const selectIsAuthenticated = (state: { auth: AuthState }) =>
+  !!state.auth.user;
+export const selectIsAuthorizedForGo = (state: { auth: AuthState }) =>
+  state.auth.isAuthorizedForGo;
+export const selectAuthLoading = (state: { auth: AuthState }) =>
+  state.auth.loading;
+export const selectAuthError = (state: { auth: AuthState }) => state.auth.error;
+
+export default authSlice.reducer;


### PR DESCRIPTION
This PR adds a dedicated authentication Redux slice to properly separate authentication state management from the generic app slice, following Redux best practices.